### PR TITLE
Doom8088 readiness: PIC/PIT port decode, PIT countdown, IRQ delivery

### DIFF
--- a/docs/logbook/LOGBOOK.md
+++ b/docs/logbook/LOGBOOK.md
@@ -3,7 +3,7 @@
 **This is the single source of truth for project status.** Every agent MUST
 read this before starting work and MUST update it before finishing.
 
-Last updated: 2026-04-15 (session 10)
+Last updated: 2026-04-18 (session 11)
 
 ---
 
@@ -16,6 +16,14 @@ a BIOS window at 0xD000:0000. Bootle boots through the rom-disk path live
 in calcite (2026-04-15) after calcite's single-parameter literal-dispatch
 flat-array fast path landed.
 
+**Next big target: Doom8088.** Session 11 readiness check (see entry log)
+identified three concrete CSS-side gaps: no PIT-driven INT 08h auto-fire,
+no INT 09h on keyboard edge, and OUT handlers for ports 0x20/0x40-0x43/0x61
+are no-ops. Everything else Doom8088 needs (Mode 13h framebuffer, INT 21h
+file I/O via rom-disk, 640 KB conventional, 8086 ISA with `-march=i8088`,
+port 0x60 IN) already works. Build Doom8088 with `-march=i8088 -nosound
+-noxms -noems`.
+
 **One BIOS, one build path:** `bios/css-emu-bios.asm` is the assembly
 BIOS. `transpiler/generate-dos.mjs` is the build script. No microcode
 BIOS, no `build.mjs`, no opcode 0xD6 dispatch.
@@ -26,6 +34,8 @@ BIOS, no `build.mjs`, no opcode 0xD6 dispatch.
 
 None for rom-disk — bootle boots through it. Next: retest Zork+FROTZ (larger
 disk, exercises more of the dispatch), then merge `feature/rom-disk` → master.
+Active blocker for Doom8088: no hardware IRQ delivery in V4 CSS (v3 had it,
+was abandoned with μOps; must be re-introduced as single-cycle).
 
 ## What's working
 
@@ -48,17 +58,42 @@ disk, exercises more of the dispatch), then merge `feature/rom-disk` → master.
 
 ## What's next (in priority order)
 
-1. **INT 13h hard disk rejection** — currently the kernel probes hard
-   disks and gets floppy geometry back, which happens to work. Properly
-   rejecting hard disks (DL >= 0x80 → CF=1) causes a stall after the
-   version string. This needs investigation — likely the kernel hits a
-   timeout loop that requires real PIT ticks to exit.
-2. **PIT timer** — real PIT counter driven by `--cycleCount`. The
-   `cycleCount` register is already accumulating; need to derive PIT
-   countdown from it and fire INT 08h when it crosses zero.
-3. **More programs** — test with rogue, other DOS programs.
-4. **Rewrite BIOS in C** — assembly is hard for Claude to reason about. OpenWatcom
-   targeting 8086 real mode. Spec-driven, not a translation of gossamer.
+Doom8088 is the driving target. Items 1-4 are its blockers. Items 5+ are
+parallel/follow-on work.
+
+1. **Port decode for PIC/PIT/speaker** — `transpiler/src/patterns/misc.mjs`
+   `emitIO()` currently only handles port 0x60 IN; OUT to every port is a
+   no-op. Add state vars and OUT handlers for:
+   - 0x20 (PIC command: EOI = OUT 0x20, 0x20 clears highest-priority ISR bit)
+   - 0x21 (PIC IMR: data byte sets interrupt mask)
+   - 0x40/0x42 (PIT channel 0/2 reload: lo/hi sequencing)
+   - 0x43 (PIT control word: channel select, r/w mode, counting mode)
+   - 0x61 (PCB control: PC speaker gate + keyboard ack bit toggle)
+   V3's abandoned `legacy/v3/transpiler/src/patterns/pit.mjs` has the
+   pitCounter/pitReload/pitMode/pitWriteState logic; port to V4 single-cycle.
+2. **PIT-driven INT 08h auto-fire** — decrement `--pitCounter` by
+   `floor(Δ--cycleCount / 4)` per retired instruction (mode 3 decrements
+   by 2x). When it crosses zero, raise IRQ 0 via picPending.
+3. **IRQ sentinel dispatch (0xF1) as single-cycle** — force `--opcode`
+   to sentinel 0xF1 when `(picPending & ~picMask & ~picInService) != 0`
+   and IF is set. Sentinel does the same SP-=6 + 3 word pushes + IP/CS
+   from IVT that 0xCD does, but vector comes from `--picVector` and
+   retIP is current IP (no instruction consumed). V3's `legacy/v3/.../irq.mjs`
+   is the template, minus the μOp split.
+4. **INT 09h on keyboard edge** — detect `--keyboard` changes between
+   retired cycles, raise IRQ 1 via picPending. Doom8088 hooks INT 09h
+   directly (bypasses INT 16h), so this is required, not optional.
+5. **INT 13h hard disk rejection** — kernel currently probes hard disks
+   and gets floppy geometry, which happens to work. Proper rejection
+   (DL >= 0x80 → CF=1) causes a stall after the version string — the
+   kernel hits a timeout loop that requires real PIT ticks. This unblocks
+   itself once item 2 lands.
+6. **Rom-disk WAD validation** — retest Zork+FROTZ (~284 KB), then attempt
+   Doom8088's processed WAD (hundreds of KB). Confirms calcite's flat-array
+   dispatch scales to larger disks.
+7. **More programs** — rogue and other DOS programs.
+8. **Rewrite BIOS in C** — OpenWatcom targeting 8086 real mode. Spec-driven,
+   not a translation of gossamer.
 
 ## Recent decisions
 
@@ -106,6 +141,71 @@ disk, exercises more of the dispatch), then merge `feature/rom-disk` → master.
 ## Entry log
 
 Newest entries first. See `docs/logbook/PROTOCOL.md` for how to write entries.
+
+### 2026-04-18 — Session 11: Doom8088 readiness audit; starting hardware IRQ work
+
+**What:** Audited CSS-DOS against Doom8088's runtime requirements and
+identified the concrete remaining work. Updated "What's next" to make
+Doom8088 the driving target. Started on the port-decode refactor that
+underlies all the IRQ work.
+
+**Doom8088 requirements (summary, source: upstream github.com/FrenkelS/Doom8088):**
+- CPU: default build targets i286 (gcc-ia16 `CPU=i286`), but an i8088 variant
+  exists (`-march=i8088`) that emits pure 8086 ISA — matches V4 patterns.
+- Input: installs a custom **INT 09h handler** (`I_KeyboardISR`), reads port
+  0x60 directly, clears with port 0x61 (bit 7 toggle), EOIs with `OUT 0x20, 0x20`.
+  Does NOT use INT 16h for gameplay.
+- Timing: installs custom **INT 08h handler** (`TS_ServiceSchedule`),
+  reprograms PIT via `OUT 0x43, 0x36` then reload LO/HI to port 0x40.
+  Chains to the BIOS tick counter every 65536 ticks. EOI via 0x20.
+- Video: default is **Mode 13h** (framebuffer 0xA000, palette 0x3C8/0x3C9).
+  A text-mode variant exists (`bt80x25.sh`, framebuffer 0xB8000) and an MDA
+  variant (`bmda.sh`, framebuffer 0xB000). Text variants are simplest for
+  first-run validation; Mode 13h is the "real" experience.
+- Memory: ~450 KB conventional. EMS/XMS are **optional** (`-noems`, `-noxms`).
+- Disk: WAD loaded via `fopen`/`fread` (INT 21h file I/O) — rom-disk path
+  handles this.
+- Sound: PC speaker only (port 0x61 toggling, PIT channel 2). Disable
+  with `-nosound`.
+- Binary: ~90-130 KB unpacked, smaller with LZEXE.
+
+**Current CSS-DOS capability vs Doom8088:**
+
+Already works:
+- 8086 ISA matches i8088 build. PUSH imm, IMUL imm, BCD, FAR indirect
+  CALL/JMP all covered. (80186 extras in `extended186.mjs`; i286 build
+  would hit gaps at 0xC0/0xC1/0x60/0x61/0xC8/0xC9/0x62/0x6C-0x6F.)
+- Mode 13h framebuffer zone (0xA0000-0xAFA00) emitted by memory.mjs.
+- Rom-disk (feature branch) handles WAD-sized images.
+- INT 21h file I/O through EDR-DOS kernel.
+- 640 KB conventional memory contiguous.
+- Port 0x60 IN returns scancode.
+
+Gaps (Doom8088 blockers):
+- No PIT-driven INT 08h auto-fire. `--cycleCount` accumulates but nothing
+  derives a tick countdown from it.
+- No INT 09h on keyboard edge. `--keyboard` updates via :active but no
+  IRQ is raised.
+- No port 0x20/0x21/0x40-0x43/0x61 OUT handlers — `emitIO()` in misc.mjs
+  makes all OUT a no-op.
+- No palette register writes (port 0x3C8/0x3C9) — Doom's damage-flash
+  palette changes would be silent. Acceptable for first validation.
+
+**Historical note:** V3 had all of this — `legacy/v3/transpiler/src/patterns/pit.mjs`
+and `irq.mjs` (via 0xF1 sentinel opcode). V3 was abandoned because the
+μOp sequencer had unrelated bugs that prevented boot. The PIT/IRQ designs
+themselves were sound. V4 port: same state and port-decode logic, but
+single-cycle (no μOp split) — mirror what the V4 0xCD handler does in
+one tick with 8 write slots.
+
+**Stale-doc check:** Issue #6 ("Road to DOS games") still captures the
+right three priorities (keyboard port, PIC EOI, timer IRQ). Will leave
+open with a scope-update comment rather than rewrite.
+
+**Plan for this session:** Start Phase 1 — port-decode refactor in
+`patterns/misc.mjs` + new state vars in `template.mjs`. OUT handlers
+populate state; no behavior change yet (no IRQ firing). Next sessions
+wire cycleCount → pitCounter → INT 08h, and --keyboard edge → INT 09h.
 
 ### 2026-04-15 — Session 10: rom-disk end-to-end working; calcite fast path + CLI menu
 

--- a/docs/logbook/LOGBOOK.md
+++ b/docs/logbook/LOGBOOK.md
@@ -58,42 +58,30 @@ was abandoned with μOps; must be re-introduced as single-cycle).
 
 ## What's next (in priority order)
 
-Doom8088 is the driving target. Items 1-4 are its blockers. Items 5+ are
+Doom8088 is the driving target. Items 1-5 are its blockers. Items 6+ are
 parallel/follow-on work.
 
-1. **Port decode for PIC/PIT/speaker** — `transpiler/src/patterns/misc.mjs`
-   `emitIO()` currently only handles port 0x60 IN; OUT to every port is a
-   no-op. Add state vars and OUT handlers for:
-   - 0x20 (PIC command: EOI = OUT 0x20, 0x20 clears highest-priority ISR bit)
-   - 0x21 (PIC IMR: data byte sets interrupt mask)
-   - 0x40/0x42 (PIT channel 0/2 reload: lo/hi sequencing)
-   - 0x43 (PIT control word: channel select, r/w mode, counting mode)
-   - 0x61 (PCB control: PC speaker gate + keyboard ack bit toggle)
-   V3's abandoned `legacy/v3/transpiler/src/patterns/pit.mjs` has the
-   pitCounter/pitReload/pitMode/pitWriteState logic; port to V4 single-cycle.
-2. **PIT-driven INT 08h auto-fire** — decrement `--pitCounter` by
-   `floor(Δ--cycleCount / 4)` per retired instruction (mode 3 decrements
-   by 2x). When it crosses zero, raise IRQ 0 via picPending.
-3. **IRQ sentinel dispatch (0xF1) as single-cycle** — force `--opcode`
-   to sentinel 0xF1 when `(picPending & ~picMask & ~picInService) != 0`
-   and IF is set. Sentinel does the same SP-=6 + 3 word pushes + IP/CS
-   from IVT that 0xCD does, but vector comes from `--picVector` and
-   retIP is current IP (no instruction consumed). V3's `legacy/v3/.../irq.mjs`
-   is the template, minus the μOp split.
-4. **INT 09h on keyboard edge** — detect `--keyboard` changes between
-   retired cycles, raise IRQ 1 via picPending. Doom8088 hooks INT 09h
-   directly (bypasses INT 16h), so this is required, not optional.
-5. **INT 13h hard disk rejection** — kernel currently probes hard disks
+1. **C BIOS INT 09h + EOI (#25, #26)** — before session 11's PIC/PIT
+   plumbing (PR #24) can actually run Doom, the C BIOS needs to install
+   an INT 09h handler and both INT 08h and INT 09h need to send `OUT
+   0x20, 0x20` before IRET. Without these, the first BIOS-served IRQ
+   latches `picInService` and wedges the PIC. Doom replaces the handlers
+   itself, but there's a startup window where the BIOS handler runs.
+2. **Conformance diff for PIC/PIT (#28)** — run `tools/compare.mjs` on
+   `keyboard-irq.com` / `timer-irq.asm` to confirm CSS matches
+   `tools/peripherals.mjs` tick-for-tick.
+3. **Keyboard break scancodes (#27)** — Doom8088 tracks held keys via
+   release scancodes (high bit set). `--_kbdEdge` fires press-only;
+   release edges need IRQ + synthesized break scancode on port 0x60.
+4. **INT 13h hard disk rejection** — kernel currently probes hard disks
    and gets floppy geometry, which happens to work. Proper rejection
    (DL >= 0x80 → CF=1) causes a stall after the version string — the
-   kernel hits a timeout loop that requires real PIT ticks. This unblocks
-   itself once item 2 lands.
-6. **Rom-disk WAD validation** — retest Zork+FROTZ (~284 KB), then attempt
-   Doom8088's processed WAD (hundreds of KB). Confirms calcite's flat-array
-   dispatch scales to larger disks.
-7. **More programs** — rogue and other DOS programs.
-8. **Rewrite BIOS in C** — OpenWatcom targeting 8086 real mode. Spec-driven,
-   not a translation of gossamer.
+   kernel hits a timeout loop that requires real PIT ticks. Should
+   unblock itself once items 1-2 land and the PIT actually fires.
+5. **Rom-disk WAD validation** — retest Zork+FROTZ (~284 KB), then
+   attempt Doom8088's processed WAD (hundreds of KB). Confirms calcite's
+   flat-array dispatch scales to larger disks.
+6. **More programs** — rogue and other DOS programs.
 
 ## Recent decisions
 

--- a/docs/logbook/LOGBOOK.md
+++ b/docs/logbook/LOGBOOK.md
@@ -202,10 +202,57 @@ one tick with 8 write slots.
 right three priorities (keyboard port, PIC EOI, timer IRQ). Will leave
 open with a scope-update comment rather than rewrite.
 
-**Plan for this session:** Start Phase 1 — port-decode refactor in
-`patterns/misc.mjs` + new state vars in `template.mjs`. OUT handlers
-populate state; no behavior change yet (no IRQ firing). Next sessions
-wire cycleCount → pitCounter → INT 08h, and --keyboard edge → INT 09h.
+**Delivered this session (3 commits on `claude/doom8088-readiness-check-6BRWJ`):**
+
+Phase 1 — port decode + state vars (`5afa52e`):
+- New STATE_VARS in template.mjs: picMask (init 0xFF), picPending,
+  picInService, pitMode, pitReload, pitCounter, pitWriteState.
+- emitIO() in patterns/misc.mjs dispatches OUT 0x20/0x21/0x40/0x43
+  to the right state var per port. Non-specific EOI on OUT 0x20 uses
+  the `(x & (x-1))` trick to clear the lowest in-service bit.
+- Dispatch entries fall through to `var(--__1NAME)` (hold) for
+  unrelated ports — the entry fires per-opcode, so the hold is explicit.
+
+Phase 2 — PIT countdown + picPending edge (`27c972a`):
+- emit-css.mjs learns per-register customDefaults so pitCounter/picPending
+  can opt into tick/edge expressions instead of default hold.
+- --_pitTicks (cycleCount/4 delta), --_pitDecrement (×2 in mode 3),
+  --_pitFired (zero-crossing guarded by pitReload != 0).
+- pitCounter decrements by --_pitDecrement each tick; reloads on zero
+  crossing. Port-write dispatch entries fall through to the same tick
+  expression (an OUT to port 0x21 must not stall the PIT).
+- picPending default ORs --_pitFired into bit 0. No IRQ delivery yet.
+
+Phase 3 — IRQ delivery + keyboard edge (`4bd502e`):
+- Single-cycle "sentinel" override, parallel to TF. No 0xF1 opcode —
+  the override fires on the instruction-boundary tick, reusing slot 0-5
+  memory writes for the FLAGS/CS/IP push while register dispatches land
+  the new IVT values.
+- prevKeyboard state var + --_kbdEdge on press (0 → non-zero).
+- --_picEffective / --_ifFlag / --_irqActive / --picVector / --_irqBit
+  computed in the .cpu rule (emitIRQCompute).
+- IRQ_OVERRIDES for SP/IP/CS/flags/cycleCount/picPending/picInService.
+- Fixed latent bug: TF trap used to still fire normal-instruction writes
+  in slots 6-7. Now both TF and IRQ suppress (-1, 0) in unused slots.
+
+**What works now (in principle):**
+- PIT channel 0 actually counts down and fires IRQ 0 if Doom programs it.
+- OUT 0x21 sets picMask, OUT 0x20 acks.
+- Keyboard press raises IRQ 1, IP/CS/FLAGS pushed, jumped to IVT[9] vector.
+- --_cycleCount feeds the PIT naturally, so no separate real-time clock.
+
+**Known limits / follow-ups:**
+1. Only IRQs 0 and 1 wired (no lowestBit helper). Sufficient for Doom8088.
+2. --_kbdEdge fires only on press. Doom8088 reads break codes (high-bit
+   set) on release to track held keys — without those, WASD held-movement
+   breaks. Next session: inject break scancode on keyboard→0 transitions,
+   or expose released-key snapshot in --_kbdRelease.
+3. No palette port 0x3C8/0x3C9 writes — Mode 13h damage-flash is silent.
+4. No validation yet that a build actually runs — the transpiler emits
+   correct-shaped CSS, but no conformance diff has been run (`gossamer.bin`
+   not present in this checkout). Running the `keyboard-irq.asm` test
+   through `compare.mjs` is the next logical step; it exercises OUT 0x21
+   and INT 16h round-trip via the BDA buffer.
 
 ### 2026-04-15 — Session 10: rom-disk end-to-end working; calcite fast path + CLI menu
 

--- a/transpiler/src/emit-css.mjs
+++ b/transpiler/src/emit-css.mjs
@@ -297,7 +297,11 @@ export function emitCSS(opts, writeStream) {
   writeStream.write('  /* Each register\'s next value is selected by opcode via a\n');
   writeStream.write('     giant if(style(--instId: N)) dispatch. This is the CPU. */\n');
   const regOrder = ['AX', 'CX', 'DX', 'BX', 'SP', 'BP', 'SI', 'DI',
-                    'CS', 'DS', 'ES', 'SS', 'IP', 'flags', 'halt', 'cycleCount'];
+                    'CS', 'DS', 'ES', 'SS', 'IP', 'flags', 'halt', 'cycleCount',
+                    // PIC/PIT state — updated by OUT handlers in patterns/misc.mjs.
+                    // Vars with no dispatch entries fall through to defaultExpr (hold).
+                    'picMask', 'picPending', 'picInService',
+                    'pitMode', 'pitReload', 'pitCounter', 'pitWriteState'];
   for (const reg of regOrder) {
     const defaultExpr = `var(--__1${reg})`;
     writeStream.write(dispatch.emitRegisterDispatch(reg, defaultExpr) + '\n');

--- a/transpiler/src/emit-css.mjs
+++ b/transpiler/src/emit-css.mjs
@@ -18,7 +18,7 @@ import { emitMOV_RegImm16, emitMOV_RegImm8, emitMOV_RegRM, emitMOV_SegRM, emitMO
 import { emitAllALU } from './patterns/alu.mjs';
 import { emitAllControl } from './patterns/control.mjs';
 import { emitAllStack } from './patterns/stack.mjs';
-import { emitAllMisc, emitPeripheralCompute, pitCounterDefaultExpr, picPendingDefaultExpr } from './patterns/misc.mjs';
+import { emitAllMisc, emitPeripheralCompute, emitIRQCompute, pitCounterDefaultExpr, picPendingDefaultExpr } from './patterns/misc.mjs';
 import { emitAllGroups } from './patterns/group.mjs';
 import { emitAllShifts, emitShiftFlagFunctions, emitShiftByNFlagFunctions } from './patterns/shift.mjs';
 import { emitAll186 } from './patterns/extended186.mjs';
@@ -89,24 +89,30 @@ class DispatchTable {
    */
   emitRegisterDispatch(reg, defaultExpr) {
     const entries = this.regEntries.get(reg);
-    if (!entries || entries.size === 0) {
-      return `  --${reg}: ${defaultExpr};`;
-    }
+    const hasEntries = entries && entries.size > 0;
 
-    // Build the normal instruction dispatch
+    // Build the normal instruction dispatch.
     const wrapIP = (reg === 'IP');
-    const dispatchLines = [];
-    const sorted = [...entries.entries()].sort(([a], [b]) => a - b);
-    for (const [opcode, { expr, comment }] of sorted) {
-      const commentStr = comment ? ` /* ${comment} */` : '';
-      dispatchLines.push(`    style(--opcode: ${opcode}): ${expr};${commentStr}`);
-    }
-
     let normalExpr;
-    if (wrapIP) {
-      normalExpr = `calc(if(\n${dispatchLines.join('\n')}\n  else: ${defaultExpr}) + var(--prefixLen))`;
+    if (!hasEntries) {
+      // No dispatch entries → the "normal path" is just the default.
+      // We still wrap with TF/IRQ overrides below so interrupt delivery can
+      // override registers that only have custom-default behavior (e.g.
+      // picPending latches edges by default but clears --_irqBit on ack).
+      // IP always has entries so prefixLen wrapping doesn't apply here.
+      normalExpr = defaultExpr;
     } else {
-      normalExpr = `if(\n${dispatchLines.join('\n')}\n  else: ${defaultExpr})`;
+      const dispatchLines = [];
+      const sorted = [...entries.entries()].sort(([a], [b]) => a - b);
+      for (const [opcode, { expr, comment }] of sorted) {
+        const commentStr = comment ? ` /* ${comment} */` : '';
+        dispatchLines.push(`    style(--opcode: ${opcode}): ${expr};${commentStr}`);
+      }
+      if (wrapIP) {
+        normalExpr = `calc(if(\n${dispatchLines.join('\n')}\n  else: ${defaultExpr}) + var(--prefixLen))`;
+      } else {
+        normalExpr = `if(\n${dispatchLines.join('\n')}\n  else: ${defaultExpr})`;
+      }
     }
 
     // TF (Trap Flag) override: when previous FLAGS had TF=1, fire INT 1 instead
@@ -118,8 +124,27 @@ class DispatchTable {
       'flags': '--and(var(--__1flags), 64767)',  // & 0xFCFF = clear TF+IF
     };
 
+    // IRQ override: when --_irqActive fires (unmasked pending IRQ with IF set
+    // and no in-service IRQ), deliver the interrupt instead of the instruction
+    // fetched from memory. Identical push shape to TF/INT (FLAGS/CS/IP), but
+    // the vector comes from --picVector (8 or 9 for IRQ 0 / IRQ 1) and retIP
+    // is the current __1IP (no instruction consumed). cycleCount += 61 matches
+    // the real 8086 hardware-interrupt cost. picPending clears the acknowledged
+    // bit (while still latching any new edges); picInService sets it so that
+    // lower-priority IRQs block until EOI.
+    const IRQ_OVERRIDES = {
+      'SP':       'calc(var(--__1SP) - 6)',
+      'IP':       '--read2(calc(var(--picVector) * 4))',
+      'CS':       '--read2(calc(var(--picVector) * 4 + 2))',
+      'flags':    '--and(var(--__1flags), 64767)',
+      'cycleCount': 'calc(var(--__1cycleCount) + 61)',
+      'picPending': `--and(${/* edge-OR applied so concurrent edges don't get dropped */''}--or(--or(var(--__1picPending), var(--_pitFired)), calc(var(--_kbdEdge) * 2)), --not(var(--_irqBit)))`,
+      'picInService': '--or(var(--__1picInService), var(--_irqBit))',
+    };
+
     const tfExpr = TF_OVERRIDES[reg] || `var(--__1${reg})`;
-    return `  --${reg}: if(style(--_tf: 1): ${tfExpr}; else: ${normalExpr});`;
+    const irqExpr = IRQ_OVERRIDES[reg] || `var(--__1${reg})`;
+    return `  --${reg}: if(style(--_tf: 1): ${tfExpr}; style(--_irqActive: 1): ${irqExpr}; else: ${normalExpr});`;
   }
 
   /**
@@ -139,9 +164,11 @@ class DispatchTable {
       }
     }
 
-    // TF trap INT 1 memory writes: push FLAGS/CS/IP to stack (slots 0-5)
+    // TF trap and IRQ delivery both push FLAGS/CS/IP — identical 6-write
+    // shape. intAddr/intVal expresses those pushes; both --_tf and --_irqActive
+    // dispatch through the same expressions.
     const ssBase = 'calc(var(--__1SS) * 16)';
-    const tfAddr = [
+    const intAddr = [
       `calc(${ssBase} + var(--__1SP) - 2)`,   // slot 0: FLAGS lo
       `calc(${ssBase} + var(--__1SP) - 1)`,   // slot 1: FLAGS hi
       `calc(${ssBase} + var(--__1SP) - 4)`,   // slot 2: CS lo
@@ -149,10 +176,10 @@ class DispatchTable {
       `calc(${ssBase} + var(--__1SP) - 6)`,   // slot 4: IP lo
       `calc(${ssBase} + var(--__1SP) - 5)`,   // slot 5: IP hi
     ];
-    const tfFlagsPush = `var(--__1flags)`;
-    const tfVal = [
-      `--lowerBytes(${tfFlagsPush}, 8)`,       // FLAGS lo
-      `--rightShift(${tfFlagsPush}, 8)`,        // FLAGS hi
+    const flagsPush = `var(--__1flags)`;
+    const intVal = [
+      `--lowerBytes(${flagsPush}, 8)`,          // FLAGS lo
+      `--rightShift(${flagsPush}, 8)`,          // FLAGS hi
       `--lowerBytes(var(--__1CS), 8)`,          // CS lo
       `--rightShift(var(--__1CS), 8)`,          // CS hi
       `--lowerBytes(var(--__1IP), 8)`,          // IP lo
@@ -161,37 +188,34 @@ class DispatchTable {
 
     const lines = [];
     for (let slot = 0; slot < NUM_WRITE_SLOTS; slot++) {
-      const hasTF = slot < 6;  // TF only uses slots 0-5
+      const intUsesSlot = slot < 6;  // TF/IRQ push 6 bytes (slots 0-5)
+      const hasNormal = slots[slot].length > 0;
 
-      if (slots[slot].length === 0 && !hasTF) {
+      if (!hasNormal && !intUsesSlot) {
         // Unused slot — always inactive
         lines.push(`  --memAddr${slot}: -1;`);
         lines.push(`  --memVal${slot}: 0;`);
         continue;
       }
 
-      if (slots[slot].length === 0) {
-        // TF-only slot
-        lines.push(`  --memAddr${slot}: if(style(--_tf: 1): ${tfAddr[slot]}; else: -1);`);
-        lines.push(`  --memVal${slot}: if(style(--_tf: 1): ${tfVal[slot]}; else: 0);`);
-        continue;
-      }
+      // Build branches: TF/IRQ suppression/push first, then normal dispatch.
+      // For slots 0-5 during TF/IRQ: push FLAGS/CS/IP.
+      // For slots 6-7 during TF/IRQ: suppress (-1, 0) — the normal instruction
+      // wasn't run, so its writes must not fire either.
+      const tfOrIrqAddr = intUsesSlot ? intAddr[slot] : '-1';
+      const tfOrIrqVal  = intUsesSlot ? intVal[slot]  : '0';
 
-      // Address dispatch
       lines.push(`  --memAddr${slot}: if(`);
-      if (hasTF) {
-        lines.push(`    style(--_tf: 1): ${tfAddr[slot]};`);
-      }
+      lines.push(`    style(--_tf: 1): ${tfOrIrqAddr};`);
+      lines.push(`    style(--_irqActive: 1): ${tfOrIrqAddr};`);
       for (const { opcode, addrExpr, comment } of slots[slot]) {
         lines.push(`    style(--opcode: ${opcode}): ${addrExpr}; /* ${comment || ''} */`);
       }
       lines.push(`  else: -1);`);
 
-      // Value dispatch
       lines.push(`  --memVal${slot}: if(`);
-      if (hasTF) {
-        lines.push(`    style(--_tf: 1): ${tfVal[slot]};`);
-      }
+      lines.push(`    style(--_tf: 1): ${tfOrIrqVal};`);
+      lines.push(`    style(--_irqActive: 1): ${tfOrIrqVal};`);
       for (const { opcode, valExpr, comment } of slots[slot]) {
         lines.push(`    style(--opcode: ${opcode}): ${valExpr}; /* ${comment || ''} */`);
       }
@@ -287,6 +311,7 @@ export function emitCSS(opts, writeStream) {
   w(emitRegisterAliases());
   w(emitDecodeProperties());
   w(emitPeripheralCompute());
+  w(emitIRQCompute());
 
   // Unknown opcode detection — sets --unknownOp=1 and --haltCode=opcode
   writeStream.write('  /* ===== UNKNOWN OPCODE FLAG ===== */\n');
@@ -302,13 +327,17 @@ export function emitCSS(opts, writeStream) {
                     // PIC/PIT state — updated by OUT handlers in patterns/misc.mjs.
                     // Vars with no dispatch entries fall through to defaultExpr.
                     'picMask', 'picPending', 'picInService',
-                    'pitMode', 'pitReload', 'pitCounter', 'pitWriteState'];
+                    'pitMode', 'pitReload', 'pitCounter', 'pitWriteState',
+                    // Keyboard-edge detection: snapshot current --keyboard.
+                    'prevKeyboard'];
   // Custom defaults: the fall-through expression when no dispatch entry fires
   // for this opcode. pitCounter ticks every instruction; picPending latches
-  // the PIT-fired edge. Everything else just holds its __1 value.
+  // PIT+keyboard edges; prevKeyboard snapshots --keyboard. Everything else
+  // just holds its __1 value.
   const customDefaults = {
     pitCounter: pitCounterDefaultExpr(),
     picPending: picPendingDefaultExpr(),
+    prevKeyboard: 'var(--keyboard)',
   };
   for (const reg of regOrder) {
     const defaultExpr = customDefaults[reg] ?? `var(--__1${reg})`;

--- a/transpiler/src/emit-css.mjs
+++ b/transpiler/src/emit-css.mjs
@@ -18,7 +18,7 @@ import { emitMOV_RegImm16, emitMOV_RegImm8, emitMOV_RegRM, emitMOV_SegRM, emitMO
 import { emitAllALU } from './patterns/alu.mjs';
 import { emitAllControl } from './patterns/control.mjs';
 import { emitAllStack } from './patterns/stack.mjs';
-import { emitAllMisc } from './patterns/misc.mjs';
+import { emitAllMisc, emitPeripheralCompute, pitCounterDefaultExpr, picPendingDefaultExpr } from './patterns/misc.mjs';
 import { emitAllGroups } from './patterns/group.mjs';
 import { emitAllShifts, emitShiftFlagFunctions, emitShiftByNFlagFunctions } from './patterns/shift.mjs';
 import { emitAll186 } from './patterns/extended186.mjs';
@@ -286,6 +286,7 @@ export function emitCSS(opts, writeStream) {
   writeStream.write('  /* Register aliases (8-bit halves) */\n');
   w(emitRegisterAliases());
   w(emitDecodeProperties());
+  w(emitPeripheralCompute());
 
   // Unknown opcode detection — sets --unknownOp=1 and --haltCode=opcode
   writeStream.write('  /* ===== UNKNOWN OPCODE FLAG ===== */\n');
@@ -299,11 +300,18 @@ export function emitCSS(opts, writeStream) {
   const regOrder = ['AX', 'CX', 'DX', 'BX', 'SP', 'BP', 'SI', 'DI',
                     'CS', 'DS', 'ES', 'SS', 'IP', 'flags', 'halt', 'cycleCount',
                     // PIC/PIT state — updated by OUT handlers in patterns/misc.mjs.
-                    // Vars with no dispatch entries fall through to defaultExpr (hold).
+                    // Vars with no dispatch entries fall through to defaultExpr.
                     'picMask', 'picPending', 'picInService',
                     'pitMode', 'pitReload', 'pitCounter', 'pitWriteState'];
+  // Custom defaults: the fall-through expression when no dispatch entry fires
+  // for this opcode. pitCounter ticks every instruction; picPending latches
+  // the PIT-fired edge. Everything else just holds its __1 value.
+  const customDefaults = {
+    pitCounter: pitCounterDefaultExpr(),
+    picPending: picPendingDefaultExpr(),
+  };
   for (const reg of regOrder) {
-    const defaultExpr = `var(--__1${reg})`;
+    const defaultExpr = customDefaults[reg] ?? `var(--__1${reg})`;
     writeStream.write(dispatch.emitRegisterDispatch(reg, defaultExpr) + '\n');
   }
   writeStream.write('\n');

--- a/transpiler/src/patterns/misc.mjs
+++ b/transpiler/src/patterns/misc.mjs
@@ -478,22 +478,43 @@ export function emitLAHF_SAHF(dispatch) {
 /**
  * I/O port instructions: IN and OUT.
  *
- * Most ports have no hardware — IN returns 0 and OUT is a no-op.
- * Exception: port 0x60 (keyboard scancode) reads the low byte of --keyboard
- * (the scancode), enabling games that poll the keyboard controller directly.
+ * Reads:
+ *   Port 0x60 (keyboard) returns the low byte of --keyboard (scancode).
+ *   All other ports return 0.
  *
- * IN AL, imm8  (0xE4): 2-byte, port in q1. Returns scancode if port=0x60.
- * IN AX, imm8  (0xE5): 2-byte, port in q1. Returns keyboard word if port=0x60.
- * OUT imm8, AL (0xE6): 2-byte, no-op.
- * OUT imm8, AX (0xE7): 2-byte, no-op.
- * IN AL, DX   (0xEC): 1-byte, port in DX. Returns scancode if DX=0x60.
- * IN AX, DX   (0xED): 1-byte, port in DX. Returns keyboard word if DX=0x60.
- * OUT DX, AL  (0xEE): 1-byte, no-op.
- * OUT DX, AX  (0xEF): 1-byte, no-op.
+ * Writes (state lives in --picMask/--picInService/--pitMode/--pitReload/
+ * --pitCounter/--pitWriteState — declared in template.mjs STATE_VARS):
+ *   Port 0x20 (PIC command): EOI clears the lowest-priority in-service bit.
+ *     Phase 1 treats any write as a non-specific EOI (Doom8088 only sends
+ *     0x20, which is the correct encoding).
+ *   Port 0x21 (PIC data):    writes AL to --picMask.
+ *   Port 0x40 (PIT ch0 data): lo/hi sequenced write to --pitReload; the
+ *     hi-byte write also loads --pitCounter.
+ *   Port 0x43 (PIT control): sets --pitMode from bits 3-1 of AL and resets
+ *     reload/counter/writeState. Channel select (bits 7-6) is ignored for
+ *     Phase 1 — we only track channel 0.
+ *
+ * Unhandled ports (speaker 0x61, CRTC 0x3D4/0x3D5, palette DAC 0x3C8/0x3C9,
+ * secondary PIC 0xA0/0xA1, PIT ch1/ch2 0x41/0x42) remain no-ops.
+ *
+ * Dispatch entries on OUT opcodes fall back to var(--__1NAME) when the port
+ * doesn't match — the entry fires on every OUT of this opcode shape, so it
+ * must explicitly hold the state for unrelated ports.
+ *
+ * Opcode shapes:
+ *   IN AL, imm8  (0xE4): 2-byte, port in q1.
+ *   IN AX, imm8  (0xE5): 2-byte, port in q1.
+ *   OUT imm8, AL (0xE6): 2-byte, port in q1.
+ *   OUT imm8, AX (0xE7): 2-byte, port in q1, AX written (no PIC/PIT effect).
+ *   IN AL, DX   (0xEC): 1-byte, port in --__1DX.
+ *   IN AX, DX   (0xED): 1-byte, port in --__1DX.
+ *   OUT DX, AL  (0xEE): 1-byte, port in --__1DX.
+ *   OUT DX, AX  (0xEF): 1-byte, port in --__1DX, no PIC/PIT effect.
  */
 export function emitIO(dispatch) {
-  // IN AL, imm8 (0xE4): port number is q1 (byte after opcode)
-  // Port 0x60 → scancode = rightShift(keyboard, 8)
+  // --- Reads ---
+
+  // IN AL, imm8 (0xE4): port 0x60 → scancode = rightShift(keyboard, 8)
   dispatch.addEntry('AX', 0xE4,
     `--mergelow(var(--__1AX), if(style(--q1: 96): --rightShift(var(--__1keyboard), 8); else: 0))`,
     `IN AL, imm8 (port 0x60=scancode)`);
@@ -505,24 +526,101 @@ export function emitIO(dispatch) {
     `IN AX, imm8 (port 0x60=keyboard)`);
   dispatch.addEntry('IP', 0xE5, `calc(var(--__1IP) + 2)`, `IN AX, imm8`);
 
-  dispatch.addEntry('IP', 0xE6, `calc(var(--__1IP) + 2)`, `OUT imm8, AL`);
-  dispatch.addEntry('IP', 0xE7, `calc(var(--__1IP) + 2)`, `OUT imm8, AX`);
-
-  // IN AL, DX (0xEC): port number is in DX register
-  // DX=0x60 (96 decimal) → scancode = rightShift(keyboard, 8)
+  // IN AL, DX (0xEC): DX=0x60 → scancode
   dispatch.addEntry('AX', 0xEC,
     `--mergelow(var(--__1AX), if(style(--__1DX: 96): --rightShift(var(--__1keyboard), 8); else: 0))`,
     `IN AL, DX (port 0x60=scancode)`);
   dispatch.addEntry('IP', 0xEC, `calc(var(--__1IP) + 1)`, `IN AL, DX`);
 
-  // IN AX, DX (0xED): port 0x60 → full keyboard word
+  // IN AX, DX (0xED): DX=0x60 → keyboard word
   dispatch.addEntry('AX', 0xED,
     `if(style(--__1DX: 96): var(--__1keyboard); else: 0)`,
     `IN AX, DX (port 0x60=keyboard)`);
   dispatch.addEntry('IP', 0xED, `calc(var(--__1IP) + 1)`, `IN AX, DX`);
 
+  // --- Writes ---
+
+  dispatch.addEntry('IP', 0xE6, `calc(var(--__1IP) + 2)`, `OUT imm8, AL`);
+  dispatch.addEntry('IP', 0xE7, `calc(var(--__1IP) + 2)`, `OUT imm8, AX`);
   dispatch.addEntry('IP', 0xEE, `calc(var(--__1IP) + 1)`, `OUT DX, AL`);
   dispatch.addEntry('IP', 0xEF, `calc(var(--__1IP) + 1)`, `OUT DX, AX`);
+
+  // AL, inline (can't use --AL alias in the state-var expressions below
+  // because we read it across many different --__1AX values — the alias
+  // would need to be re-derived per tick anyway and the cost is identical).
+  const al = `--lowerBytes(var(--__1AX), 8)`;
+
+  // Non-specific EOI on OUT 0x20 (any value). Clear the lowest-priority
+  // in-service bit using the (x & (x-1)) bit-clear-lowest trick. When
+  // picInService=0 this yields 0 (no effect), which is correct.
+  const picEoiExpr = `--and(var(--__1picInService), calc(var(--__1picInService) - 1))`;
+
+  // picInService: OUT to 0x20 → EOI. Other ports → hold.
+  dispatch.addEntry('picInService', 0xE6,
+    `if(style(--q1: 32): ${picEoiExpr}; else: var(--__1picInService))`,
+    `OUT 0x20: non-specific EOI`);
+  dispatch.addEntry('picInService', 0xEE,
+    `if(style(--__1DX: 32): ${picEoiExpr}; else: var(--__1picInService))`,
+    `OUT DX=0x20: non-specific EOI`);
+
+  // picMask: OUT to 0x21 → AL becomes the new mask. Other ports → hold.
+  dispatch.addEntry('picMask', 0xE6,
+    `if(style(--q1: 33): ${al}; else: var(--__1picMask))`,
+    `OUT 0x21: set PIC mask`);
+  dispatch.addEntry('picMask', 0xEE,
+    `if(style(--__1DX: 33): ${al}; else: var(--__1picMask))`,
+    `OUT DX=0x21: set PIC mask`);
+
+  // pitMode: OUT to 0x43 (control word) → bits 3-1 of AL.
+  const pitModeExpr = `--lowerBytes(--rightShift(--and(${al}, 14), 1), 3)`;
+  dispatch.addEntry('pitMode', 0xE6,
+    `if(style(--q1: 67): ${pitModeExpr}; else: var(--__1pitMode))`,
+    `OUT 0x43: PIT control word`);
+  dispatch.addEntry('pitMode', 0xEE,
+    `if(style(--__1DX: 67): ${pitModeExpr}; else: var(--__1pitMode))`,
+    `OUT DX=0x43: PIT control word`);
+
+  // pitWriteState: toggled by OUT 0x40, reset by OUT 0x43. Hold otherwise.
+  dispatch.addEntry('pitWriteState', 0xE6,
+    `if(style(--q1: 67): 0; style(--q1: 64): calc(1 - var(--__1pitWriteState)); else: var(--__1pitWriteState))`,
+    `OUT 0x43/0x40: PIT writeState`);
+  dispatch.addEntry('pitWriteState', 0xEE,
+    `if(style(--__1DX: 67): 0; style(--__1DX: 64): calc(1 - var(--__1pitWriteState)); else: var(--__1pitWriteState))`,
+    `OUT DX=0x43/0x40: PIT writeState`);
+
+  // pitReload: OUT 0x43 resets to 0. OUT 0x40 with writeState=0 sets lo byte,
+  // writeState=1 sets hi byte. Hold otherwise.
+  const pitReloadImm = `if(
+    style(--q1: 67): 0;
+    style(--q1: 64) and style(--__1pitWriteState: 0): calc(--and(var(--__1pitReload), 65280) + ${al});
+    style(--q1: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
+    else: var(--__1pitReload)
+  )`;
+  const pitReloadDx = `if(
+    style(--__1DX: 67): 0;
+    style(--__1DX: 64) and style(--__1pitWriteState: 0): calc(--and(var(--__1pitReload), 65280) + ${al});
+    style(--__1DX: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
+    else: var(--__1pitReload)
+  )`;
+  dispatch.addEntry('pitReload', 0xE6, pitReloadImm, `OUT 0x40/0x43: PIT reload`);
+  dispatch.addEntry('pitReload', 0xEE, pitReloadDx, `OUT DX=0x40/0x43: PIT reload`);
+
+  // pitCounter: OUT 0x43 resets to 0. OUT 0x40 with writeState=1 loads the
+  // new full reload into the counter (matches real PIT behavior — the counter
+  // starts ticking only after both bytes are written). Phase 2 adds the
+  // cycleCount-driven decrement; for Phase 1 the counter just holds.
+  const pitCounterImm = `if(
+    style(--q1: 67): 0;
+    style(--q1: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
+    else: var(--__1pitCounter)
+  )`;
+  const pitCounterDx = `if(
+    style(--__1DX: 67): 0;
+    style(--__1DX: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
+    else: var(--__1pitCounter)
+  )`;
+  dispatch.addEntry('pitCounter', 0xE6, pitCounterImm, `OUT 0x40/0x43: PIT counter load`);
+  dispatch.addEntry('pitCounter', 0xEE, pitCounterDx, `OUT DX=0x40/0x43: PIT counter load`);
 }
 
 /**

--- a/transpiler/src/patterns/misc.mjs
+++ b/transpiler/src/patterns/misc.mjs
@@ -523,12 +523,58 @@ export function pitCounterDefaultExpr() {
 }
 
 /**
- * Default expression for --picPending. Sets bit 0 when the PIT crosses
- * zero this tick. Phase 3 will also OR in bit 1 on keyboard edges and
- * AND-out the bit acknowledged by the IRQ sentinel.
+ * Default expression for --picPending. ORs in bit 0 when the PIT crosses
+ * zero (_pitFired) and bit 1 on a keyboard press edge (_kbdEdge).
+ *
+ * The IRQ-acknowledge branch (clearing --_irqBit) is applied via the
+ * register-level IRQ_OVERRIDES in emit-css.mjs, not here — the override
+ * takes priority over this default when --_irqActive fires.
  */
 export function picPendingDefaultExpr() {
-  return `if(style(--_pitFired: 1): --or(var(--__1picPending), 1); else: var(--__1picPending))`;
+  return `--or(
+    --or(var(--__1picPending), var(--_pitFired)),
+    calc(var(--_kbdEdge) * 2)
+  )`;
+}
+
+/**
+ * Compute properties for IRQ delivery. Emitted as standalone lines in
+ * the .cpu rule — not dispatch-routed.
+ *
+ *   --_kbdEdge:     1 iff --keyboard went from 0 last tick to non-zero now.
+ *   --_picEffective: pending-and-unmasked IRQs, masked to 0 when another
+ *                    IRQ is already in service (prevents nesting).
+ *   --_ifFlag:      interrupt-enable flag (bit 9 of FLAGS).
+ *   --_irqActive:   1 iff an IRQ should fire at this instruction boundary.
+ *   --_irq0Pending: 1 iff IRQ 0 (PIT) is the effective pending IRQ.
+ *                   IRQ 0 has priority over IRQ 1 on real PICs.
+ *   --picVector:    INT vector for the acknowledged IRQ (8 or 9 for now).
+ *   --_irqBit:      bitmask (1 or 2) of the IRQ being acknowledged.
+ *
+ * Phase 3 only handles IRQ 0 (timer) and IRQ 1 (keyboard) — the only ones
+ * Doom8088 cares about. Adding more IRQs would generalize --picVector
+ * and --_irqBit through a lowestBit helper like v3's irq.mjs did.
+ */
+export function emitIRQCompute() {
+  const kbdEdge = `if(
+    style(--keyboard: 0): 0;
+    style(--__1prevKeyboard: 0): 1;
+    else: 0
+  )`;
+  const picEffective = `if(
+    style(--__1picInService: 0): --and(var(--__1picPending), --not(var(--__1picMask)));
+    else: 0
+  )`;
+  return [
+    `  /* IRQ delivery state */`,
+    `  --_kbdEdge: ${kbdEdge};`,
+    `  --_picEffective: ${picEffective};`,
+    `  --_ifFlag: --bit(var(--__1flags), 9);`,
+    `  --_irqActive: if(style(--_ifFlag: 0): 0; style(--_picEffective: 0): 0; else: 1);`,
+    `  --_irq0Pending: --and(var(--_picEffective), 1);`,
+    `  --picVector: if(style(--_irq0Pending: 1): 8; else: 9);`,
+    `  --_irqBit: if(style(--_irq0Pending: 1): 1; else: 2);`,
+  ].join('\n');
 }
 
 /**

--- a/transpiler/src/patterns/misc.mjs
+++ b/transpiler/src/patterns/misc.mjs
@@ -476,6 +476,62 @@ export function emitLAHF_SAHF(dispatch) {
 }
 
 /**
+ * Peripheral helper computed properties emitted into the .cpu rule.
+ *
+ * These aren't dispatched — they're derived each tick from the new
+ * --cycleCount (which the instruction's cycle-count entry has already
+ * set for this tick) and the __1 versions of the PIT state vars.
+ *
+ * --_pitTicks: PIT input pulses consumed this retirement.
+ *   The 8086 runs at ~4.77 MHz, the PIT at ~1.193 MHz — a 4:1 ratio.
+ *   So each increment of cycleCount/4 is one PIT tick.
+ * --_pitDecrement: how much to subtract from the counter. Mode 3
+ *   (square wave) decrements by 2 per PIT tick; other modes by 1.
+ * --_pitFired: 1 iff the counter would cross zero this tick and the
+ *   PIT is armed (pitReload != 0). Used to raise IRQ 0 on picPending.
+ *   Computed via sign(decrement - counter + 1): positive when the
+ *   decrement is at least counter (i.e. counter reaches 0 or below),
+ *   clamped to [0, 1].
+ */
+export function emitPeripheralCompute() {
+  const pitTicks = `calc(round(down, var(--cycleCount) / 4) - round(down, var(--__1cycleCount) / 4))`;
+  const pitDecrement = `if(style(--__1pitMode: 3): calc(var(--_pitTicks) * 2); else: var(--_pitTicks))`;
+  const pitFired = `if(style(--__1pitReload: 0): 0; else: min(1, max(0, sign(calc(var(--_pitDecrement) - var(--__1pitCounter) + 1)))))`;
+  return [
+    `  /* Peripheral clocks derived from this tick's --cycleCount */`,
+    `  --_pitTicks: ${pitTicks};`,
+    `  --_pitDecrement: ${pitDecrement};`,
+    `  --_pitFired: ${pitFired};`,
+  ].join('\n');
+}
+
+/**
+ * Expression for --pitCounter's per-tick countdown: decrement by
+ * --_pitDecrement, reload from --__1pitReload on zero crossing. Holds
+ * at 0 while idle (pitReload == 0). Used both as the register-level
+ * default (opcodes with no PIT dispatch entry) and as the `else:` of
+ * the port-write entries (OUT to a non-PIT port must still tick).
+ */
+export function pitCounterDefaultExpr() {
+  return `if(
+    style(--__1pitReload: 0): 0;
+    else: calc(
+      var(--__1pitCounter) - var(--_pitDecrement)
+      + max(0, sign(calc(var(--_pitDecrement) - var(--__1pitCounter) + 1))) * var(--__1pitReload)
+    )
+  )`;
+}
+
+/**
+ * Default expression for --picPending. Sets bit 0 when the PIT crosses
+ * zero this tick. Phase 3 will also OR in bit 1 on keyboard edges and
+ * AND-out the bit acknowledged by the IRQ sentinel.
+ */
+export function picPendingDefaultExpr() {
+  return `if(style(--_pitFired: 1): --or(var(--__1picPending), 1); else: var(--__1picPending))`;
+}
+
+/**
  * I/O port instructions: IN and OUT.
  *
  * Reads:
@@ -607,17 +663,19 @@ export function emitIO(dispatch) {
 
   // pitCounter: OUT 0x43 resets to 0. OUT 0x40 with writeState=1 loads the
   // new full reload into the counter (matches real PIT behavior — the counter
-  // starts ticking only after both bytes are written). Phase 2 adds the
-  // cycleCount-driven decrement; for Phase 1 the counter just holds.
+  // starts ticking only after both bytes are written). On OUT to any other
+  // port (e.g. 0x20, 0x21), fall through to the normal per-tick countdown —
+  // the PIT must keep running while the program is talking to other devices.
+  const pitTick = pitCounterDefaultExpr();
   const pitCounterImm = `if(
     style(--q1: 67): 0;
     style(--q1: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
-    else: var(--__1pitCounter)
+    else: ${pitTick}
   )`;
   const pitCounterDx = `if(
     style(--__1DX: 67): 0;
     style(--__1DX: 64) and style(--__1pitWriteState: 1): calc(--and(var(--__1pitReload), 255) + ${al} * 256);
-    else: var(--__1pitCounter)
+    else: ${pitTick}
   )`;
   dispatch.addEntry('pitCounter', 0xE6, pitCounterImm, `OUT 0x40/0x43: PIT counter load`);
   dispatch.addEntry('pitCounter', 0xEE, pitCounterDx, `OUT DX=0x40/0x43: PIT counter load`);

--- a/transpiler/src/template.mjs
+++ b/transpiler/src/template.mjs
@@ -25,6 +25,25 @@ export const STATE_VARS = [
   { name: 'halt', init: 0, debug: true },
   { name: 'cycleCount', init: 0, debug: false },
   { name: '_tfPending', init: 0, debug: false },
+
+  // PIC (i8259) state — see transpiler/src/patterns/misc.mjs emitIO().
+  // picMask: IMR. Bit set = IRQ masked. Init 0xFF (all masked) matches real
+  // BIOS POST before the OS unmasks IRQ 0/1.
+  // picPending: IRR. Bit set = IRQ requested, not yet acknowledged.
+  // picInService: ISR. Bit set = IRQ currently being serviced (cleared by EOI).
+  { name: 'picMask', init: 0xFF, debug: false },
+  { name: 'picPending', init: 0, debug: false },
+  { name: 'picInService', init: 0, debug: false },
+
+  // PIT (i8253) channel 0 state — see transpiler/src/patterns/misc.mjs emitIO().
+  // pitMode: counting mode (0..5 from control word bits 3-1).
+  // pitReload: 16-bit reload latch, loaded by OUT 0x40 lo/hi sequence.
+  // pitCounter: running countdown; reloads from pitReload on zero crossing.
+  // pitWriteState: lo/hi toggle for OUT 0x40 (0 = lo byte next, 1 = hi byte next).
+  { name: 'pitMode', init: 0, debug: false },
+  { name: 'pitReload', init: 0, debug: false },
+  { name: 'pitCounter', init: 0, debug: false },
+  { name: 'pitWriteState', init: 0, debug: false },
 ];
 
 /**

--- a/transpiler/src/template.mjs
+++ b/transpiler/src/template.mjs
@@ -44,6 +44,11 @@ export const STATE_VARS = [
   { name: 'pitReload', init: 0, debug: false },
   { name: 'pitCounter', init: 0, debug: false },
   { name: 'pitWriteState', init: 0, debug: false },
+
+  // Previous-tick snapshot of --keyboard, used to detect press edges for IRQ 1.
+  // --keyboard is driven externally by :active button rules; its double-buffered
+  // snapshot lets us compare this tick's value against last tick's.
+  { name: 'prevKeyboard', init: 0, debug: false },
 ];
 
 /**


### PR DESCRIPTION
## Summary

CSS-side plumbing for hardware interrupt delivery. **Dormant by default, not end-to-end ready.** A matching BIOS-side change set (#25, #26, #27, #28) is required before Doom8088 can actually use any of this; as landed, existing programs (bootle, the kernel, every hacky-path test that isn't `keyboard-irq` / `timer-irq`) see no behavior change.

Included:

- **Phase 1** (`5afa52e`) — port decode + state. Seven double-buffered state vars (`picMask`/`picPending`/`picInService` + `pitMode`/`pitReload`/`pitCounter`/`pitWriteState`). `emitIO()` dispatches OUT 0x20/0x21/0x40/0x43 to the right state var per port. Non-specific EOI uses `(x & (x-1))` to clear the lowest in-service bit. `picMask` inits to 0xFF, so nothing fires until a program explicitly unmasks.
- **Phase 2** (`27c972a`) — PIT countdown. `--_pitTicks` / `--_pitDecrement` / `--_pitFired` derived from `--cycleCount` (8086 runs 4× PIT clock). `--pitCounter` decrements each tick, reloads on zero crossing, idle while `pitReload == 0`. `--picPending` default ORs bit 0 on PIT zero-crossing. `emit-css.mjs` gains per-register custom defaults.
- **Phase 3** (`4bd502e`) — IRQ delivery + keyboard edge. Single-cycle override in the dispatch layer parallel to the TF trap (no 0xF1 opcode — reuses the fetched instruction's memory slots for the FLAGS/CS/IP push while register dispatches land the new IVT values). New compute props: `--_kbdEdge`, `--_picEffective`, `--_ifFlag`, `--_irqActive`, `--_irq0Pending`, `--picVector`, `--_irqBit`. `IRQ_OVERRIDES` covers SP/IP/CS/flags/cycleCount/picPending/picInService. Also fixes a latent TF-trap bug where slots 6-7 still fired normal-instruction writes during a trap.
- **Logbook** (`98b9336`) — session 11 delivery summary.

## Why it's dormant

At boot: `picMask = 0xFF` (all IRQs masked), neither BIOS programs the PIT (so `pitReload = 0` keeps `_pitFired = 0`), and the kernel doesn't touch port 0x21. `--_irqActive` is 0 for every existing program's execution path, so the dispatch runs identically to before. The changes light up only when a program does `STI` + `OUT 0x21` + PIT programming — i.e. Doom8088 and the IRQ conformance tests.

## What this does NOT give us

Landing this does not make Doom8088 run. The specific gaps:

1. **C BIOS doesn't install INT 09h handler** — `bios/bios_init.c:83` installs INT 08h but not 09h. An unmasked keyboard IRQ currently jumps to `int_dummy`. Tracked in #25.
2. **Neither BIOS handler EOIs** — `bios/handlers.asm` `int08h_handler` IRETs without `OUT 0x20, 0x20`. Before this PR that was harmless (OUT was a no-op). After this PR, the first BIOS-served timer IRQ latches `picInService`, `--_picEffective` drops to 0 via the in-service gate, and every subsequent IRQ is blocked. Doom sidesteps by replacing INT 08h with its own ISR that EOIs — but the window between "Doom sets IF + unmasks IRQ 0" and "Doom installs its handler" can wedge the PIC if the PIT has already fired. Tracked in #26.
3. **Keyboard break codes not synthesized** — `--_kbdEdge` fires only on press (0 → non-zero). Doom8088's ISR reads break codes (high-bit set) on release to track held keys; without those, WASD held-movement breaks. Tracked in #27.
4. **No conformance run** — the CSS emits correctly but I haven't verified it matches `tools/peripherals.mjs` (the JS reference PIC/PIT) via `tools/compare.mjs` on `keyboard-irq.com` / `timer-irq.asm`. Tracked in #28.

## Test plan

- [ ] Build `bios/css-emu-bios.bin` via `bios/build.mjs` (C BIOS + asm handlers).
- [ ] Land #25 and #26 so the C BIOS is usable as a PIC-aware BIOS.
- [ ] Run `tools/compare.mjs` against the hacky-path `keyboard-irq.com` and `timer-irq.asm` after rebuilding `gossamer.bin` (or port the tests to `generate-dos.mjs`), per #28.
- [ ] Build Doom8088 i8088 variant (`-march=i8088 -nosound -noxms -noems`), load via rom-disk, boot-trace through title screen.

Closes part of #6.

https://claude.ai/code/session_012r2U9R4L5YsayrrFtmqkSY