### PR TITLE
fix: SCASW use pre-computed --_strDstByte instead of inline --read2()

### DIFF
--- a/kiln/patterns/misc.mjs
+++ b/kiln/patterns/misc.mjs
@@ -300,7 +300,7 @@ function emitSCAS(dispatch) {
   dispatch.addEntry('IP', 0xAE, repCondIP(), `SCASB`);
 
   dispatch.addEntry('flags', 0xAF,
-    repGuardReg(`calc(--subFlags16(var(--__1AX), --read2(calc(var(--__1ES) * 16 + var(--__1DI)))) + --and(var(--__1flags), 1792))`, `var(--__1flags)`),
+    repGuardReg(`calc(--subFlags16(var(--__1AX), calc(var(--_strDstByte) + var(--_strDstHiByte) * 256)) + --and(var(--__1flags), 1792))`, `var(--__1flags)`),
     `SCASW flags`);
   dispatch.addEntry('DI', 0xAF,
     repGuardReg(strAdjust('DI', 2), `var(--__1DI)`),


### PR DESCRIPTION
SCASW (opcode 0xAF) was the only string operation using an inline --read2(calc(var(--__1ES) * 16 + var(--__1DI))) instead of the pre-computed --_strDstByte / --_strDstHiByte variables defined in decode.mjs (lines 368-371).

All other string ops (CMPSB, CMPSW, SCASB, LODSB, LODSW, STOSB, STOSW, MOVSB, MOVSW) already use these pre-computed variables. The inline read bypasses the pre-computation that was added specifically to prevent miscompilation in calcite's near-identity dispatch path (see decode.mjs comment on line 366).

The fix aligns SCASW with the CMPSW pattern:
  calc(var(--_strDstByte) + var(--_strDstHiByte) * 256)

Fixes #19