### PR TITLE
fix: auto-install web/site dependencies via postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "css-dos-build": "builder/build.mjs"
   },
   "scripts": {
+    "postinstall": "npm --prefix web/site install",
     "build": "node builder/build.mjs",
     "dev": "npm --prefix web/site run dev",
     "site:build": "npm --prefix web/site run build",


### PR DESCRIPTION
Running 'npm run dev' after a fresh clone fails because web/site/ has its own package.json with Vite, Svelte, and other devDependencies that are not installed by the root 'npm install'.

Add a postinstall script that runs 'npm --prefix web/site install' automatically, so 'npm install && npm run dev' works out of the box.

Fixes #35