### PR TITLE
refactor: unify interrupt frame across INT/INT3/INTO/TF/IRQ

### DIFF
--- a/kiln/emit-css.mjs
+++ b/kiln/emit-css.mjs
@@ -16,6 +16,7 @@ import { emitWriteSlotProperties, emitDiskAddrProperties, buildInitialMemory, bu
          NUM_WRITE_SLOTS, PACK_SIZE, buildCellSet, buildInitialMemoryPacked,
          cellIdxOf, cellOffOf, cellBase } from './memory.mjs';
 import { emitFlagFunctions } from './patterns/flags.mjs';
+import { spDecBy, stackWriteAddr, INT_CLEAR_FLAGS_EXPR, INT_FRAME } from './patterns/stack-addr.mjs';
 
 // Opcode emitters
 import { emitAllMOV } from './patterns/mov.mjs';
@@ -228,11 +229,13 @@ class DispatchTable {
 
     // TF (Trap Flag) override: when previous FLAGS had TF=1, fire INT 1 instead
     // of the normal instruction. INT 1: push FLAGS/CS/IP, clear TF+IF, jump to IVT[1].
+    // SP uses spDecBy(6) for the --lowerBytes wrap — the old `calc(SP - 6)` would
+    // underflow at SP ≤ 5 (same fix as control.mjs / misc.mjs / stack.mjs).
     const TF_OVERRIDES = {
       'IP':    'var(--_tfIP)',
       'CS':    'var(--_tfCS)',
-      'SP':    'calc(var(--__1SP) - 6)',
-      'flags': '--and(var(--__1flags), 64767)',  // & 0xFCFF = clear TF+IF
+      'SP':    spDecBy(6),
+      'flags': INT_CLEAR_FLAGS_EXPR,
     };
 
     // IRQ override: when --_irqActive fires (unmasked pending IRQ with IF set
@@ -244,10 +247,10 @@ class DispatchTable {
     // bit (while still latching any new edges); picInService sets it so that
     // lower-priority IRQs block until EOI.
     const IRQ_OVERRIDES = {
-      'SP':       'calc(var(--__1SP) - 6)',
+      'SP':       spDecBy(6),
       'IP':       '--read2(calc(var(--picVector) * 4))',
       'CS':       '--read2(calc(var(--picVector) * 4 + 2))',
-      'flags':    '--and(var(--__1flags), 64767)',
+      'flags':    INT_CLEAR_FLAGS_EXPR,
       'cycleCount': 'calc(var(--__1cycleCount) + 61)',
       // Edge-OR applied so concurrent edges don't get dropped. The latch
       // expression is settable (this.picPendingLatchExpr) because mouse
@@ -313,26 +316,15 @@ class DispatchTable {
     // TF trap and IRQ delivery both push FLAGS/CS/IP - three word-aligned
     // pushes. Each lands in one width=2 slot. Stack is always even-aligned
     // (SP starts even, decrements by 2) so no straddle here.
-    const ssBase = 'calc(var(--__1SS) * 16)';
-    // Wrap SP-K to 16 bits - without this, IRQ/TF push at SP=0 lands one
-    // segment too low (SS:0xFFFE != SS-1:0xFFFE). Same fix as PUSH/CALL/INT
-    // in kiln/patterns/{stack,control,misc,group}.mjs.
-    const sa = (k) => `calc(${ssBase} + --lowerBytes(calc(var(--__1SP) - ${k} + 65536), 16))`;
-    const intAddr = [
-      sa(2),   // slot 0: FLAGS at SP-2..SP-1
-      sa(4),   // slot 1: CS at SP-4..SP-3
-      sa(6),   // slot 2: IP at SP-6..SP-5
-    ];
+    // Addresses and values derived from INT_FRAME (stack-addr.mjs) so every
+    // INT-family path shares the same frame layout definition.
+    const intAddr = INT_FRAME.map(f => stackWriteAddr(f.offset));
     const intVal = [
       `var(--__1flags)`,
       `var(--__1CS)`,
       `var(--__1IP)`,
     ];
-    const intFrameWord = [
-      'FLAGS at SS:SP-2',
-      'CS at SS:SP-4',
-      'IP at SS:SP-6',
-    ];
+    const intFrameWord = INT_FRAME.map(f => `${f.name} at SS:SP-${f.offset}`);
     const slotRole = [
       'every writing opcode\'s first (or only) write',
       'used only by multi-write opcodes: the second byte/word they write this tick',

--- a/kiln/patterns/control.mjs
+++ b/kiln/patterns/control.mjs
@@ -3,7 +3,7 @@
 // Flag bit positions for condition checks
 // CF=bit0, PF=bit2, AF=bit4, ZF=bit6, SF=bit7, OF=bit11
 
-import { stackWriteAddr, spDecBy, spIncBy, stackReadWord } from './stack-addr.mjs';
+import { stackWriteAddr, spDecBy, spIncBy, stackReadWord, emitIntFrame } from './stack-addr.mjs';
 
 /**
  * Conditional jump condition expressions.
@@ -134,56 +134,11 @@ export function emitRET_imm(dispatch) {
  * Uses 6 memory write slots (3 word pushes).
  */
 export function emitINT(dispatch) {
-  // Interrupt number is at q1 (byte after opcode)
-  // IVT entry at intNum * 4: 2 bytes IP, 2 bytes CS
-  // Stack: SP -= 6 (push FLAGS, CS, IP+2)
-
-  dispatch.addEntry('SP', 0xCD, spDecBy(6), `INT (SP-=6)`);
-
-  // New IP from IVT: read2(intNum * 4)
-  dispatch.addEntry('IP', 0xCD,
-    `--read2(calc(var(--q1) * 4))`,
-    `INT load IP from IVT`);
-
-  // New CS from IVT: read2(intNum * 4 + 2)
-  dispatch.addEntry('CS', 0xCD,
-    `--read2(calc(var(--q1) * 4 + 2))`,
-    `INT load CS from IVT`);
-
-  // FLAGS: clear IF (bit 9) and TF (bit 8) - keep other bits
-  // new flags = old flags & ~0x0300 = old flags & 0xFCFF
-  // But this is the pushed value; the new flags register value has IF+TF cleared
-  dispatch.addEntry('flags', 0xCD,
-    `--and(var(--__1flags), 64767)`,
-    `INT clear IF+TF`);
-  // 64767 = 0xFCFF = ~(IF|TF) & 0xFFFF
-
-  const retIP = `calc(var(--__1IP) + 2)`;
-
-  // 8086 INT pushes: FLAGS first (to highest addr), then CS, then IP (to lowest addr)
-  // After SP -= 6, stack layout is:
-  //   [SP+0, SP+1] = return IP   (pushed last)
-  //   [SP+2, SP+3] = CS          (pushed second)
-  //   [SP+4, SP+5] = FLAGS       (pushed first)
-  // All offsets are wrapped to 16-bit unsigned via stackWriteAddr().
-
-  // Push FLAGS (word at SP-2, SP-1) - pushed first, goes to highest address
-  dispatch.addMemWriteWord(0xCD,
-    stackWriteAddr(2),
-    `var(--__1flags)`,
-    `INT push FLAGS`);
-
-  // Push CS (word at SP-4, SP-3)
-  dispatch.addMemWriteWord(0xCD,
-    stackWriteAddr(4),
-    `var(--__1CS)`,
-    `INT push CS`);
-
-  // Push return IP (word at SP-6, SP-5) - pushed last, goes to lowest address
-  dispatch.addMemWriteWord(0xCD,
-    stackWriteAddr(6),
-    retIP,
-    `INT push IP`);
+  emitIntFrame(dispatch, 0xCD, {
+    vectorExpr: 'var(--q1)',
+    retIPExpr:  'calc(var(--__1IP) + 2)',
+    label:      'INT',
+  });
 }
 
 /**

--- a/kiln/patterns/misc.mjs
+++ b/kiln/patterns/misc.mjs
@@ -1,7 +1,7 @@
 // Miscellaneous instructions: HLT, NOP, LODSB, MOV r/m imm, flag manipulation, etc.
 
 import { REG16, SPLIT_REGS } from './regs.mjs';
-import { stackWriteAddr as sa, spDecBy, stackReadWord } from './stack-addr.mjs';
+import { stackWriteAddr as sa, spDecBy, stackReadWord, emitIntFrame, INT_CLEAR_FLAGS_EXPR } from './stack-addr.mjs';
 
 // ===== REP PREFIX HELPERS =====
 // These helpers wrap string operation expressions to handle REP/REPE/REPNE prefixes.
@@ -1313,42 +1313,11 @@ function emitXLAT(dispatch) {
  * Same as INT 0xCD but interrupt number = 3, return IP = IP + 1.
  */
 function emitINT3(dispatch) {
-  dispatch.addEntry('SP', 0xCC, spDecBy(6), `INT 3 (SP-=6)`);
-
-  // Load new IP from IVT[3*4] = IVT[12]
-  dispatch.addEntry('IP', 0xCC,
-    `--read2(12)`,
-    `INT 3 load IP from IVT`);
-
-  // Load new CS from IVT[3*4+2] = IVT[14]
-  dispatch.addEntry('CS', 0xCC,
-    `--read2(14)`,
-    `INT 3 load CS from IVT`);
-
-  // Clear IF (bit 9) and TF (bit 8): flags & 0xFCFF = flags & 64767
-  dispatch.addEntry('flags', 0xCC,
-    `--and(var(--__1flags), 64767)`,
-    `INT 3 clear IF+TF`);
-
-  const retIP = `calc(var(--__1IP) + 1)`;
-
-  // Push FLAGS (word at SP-2/SP-1, highest address, pushed first)
-  dispatch.addMemWriteWord(0xCC,
-    sa(2),
-    `var(--__1flags)`,
-    `INT 3 push FLAGS`);
-
-  // Push CS (word at SP-4/SP-3)
-  dispatch.addMemWriteWord(0xCC,
-    sa(4),
-    `var(--__1CS)`,
-    `INT 3 push CS`);
-
-  // Push return IP (word at SP-6/SP-5, lowest address, pushed last)
-  dispatch.addMemWriteWord(0xCC,
-    sa(6),
-    retIP,
-    `INT 3 push IP`);
+  emitIntFrame(dispatch, 0xCC, {
+    vectorExpr: '3',
+    retIPExpr:  'calc(var(--__1IP) + 1)',
+    label:      'INT 3',
+  });
 }
 
 /**
@@ -1359,7 +1328,6 @@ function emitINTO(dispatch) {
   // OF = bit 11 of flags. Use arithmetic mux since --_of isn't a decode property.
   // ofBit is 0 or 1. Arithmetic: of*trueVal + (1-of)*falseVal
   const ofBit = `--bit(var(--__1flags), 11)`;
-  const ssBase = `calc(var(--__1SS) * 16)`;
   const retIP = `calc(var(--__1IP) + 1)`;
 
   // SP: if OF, SP -= 6; else unchanged. Wrap to 16 bits for the OF=1 case.
@@ -1367,25 +1335,23 @@ function emitINTO(dispatch) {
     `calc(${ofBit} * ${spDecBy(6)} + (1 - ${ofBit}) * var(--__1SP))`,
     `INTO (SP-=6 if OF)`);
 
-  // IP: if OF, load from IVT[16]; else IP + 1
+  // IP: if OF, load from IVT[4*4=16]; else IP + 1
   dispatch.addEntry('IP', 0xCE,
     `calc(${ofBit} * --read2(16) + (1 - ${ofBit}) * (var(--__1IP) + 1))`,
     `INTO load IP`);
 
-  // CS: if OF, load from IVT[18]; else unchanged
+  // CS: if OF, load from IVT[4*4+2=18]; else unchanged
   dispatch.addEntry('CS', 0xCE,
     `calc(${ofBit} * --read2(18) + (1 - ${ofBit}) * var(--__1CS))`,
     `INTO load CS`);
 
   // flags: if OF, clear IF+TF; else unchanged
   dispatch.addEntry('flags', 0xCE,
-    `calc(${ofBit} * --and(var(--__1flags), 64767) + (1 - ${ofBit}) * var(--__1flags))`,
+    `calc(${ofBit} * ${INT_CLEAR_FLAGS_EXPR} + (1 - ${ofBit}) * var(--__1flags))`,
     `INTO clear IF+TF if OF`);
 
-  // Memory pushes (words) - addr uses arithmetic mux: of*real_addr +
-  // (1-of)*(-1), so the frame is suppressed (addr -1) when OF is clear.
-  // The address arm passed to addMemWriteWord is the word's lo address;
-  // the hi byte lands at addr+1 as usual.
+  // Memory pushes: addr uses arithmetic mux: of*real_addr + (1-of)*(-1),
+  // so the frame is suppressed (addr -1) when OF is clear.
   dispatch.addMemWriteWord(0xCE,
     `calc(${ofBit} * (${sa(2)}) + (1 - ${ofBit}) * (-1))`,
     `var(--__1flags)`,

--- a/kiln/patterns/stack-addr.mjs
+++ b/kiln/patterns/stack-addr.mjs
@@ -34,3 +34,70 @@ export function spIncBy(n) {
 export function stackReadWord() {
   return `--read2(calc(var(--__1SS) * 16 + var(--__1SP)))`;
 }
+
+// --- Interrupt frame shared constants ---
+// Every INT-family instruction (INT, INT3, INTO, TF trap, HW IRQ) pushes
+// the same three words: FLAGS at SP-2, CS at SP-4, return IP at SP-6, and
+// clears IF+TF in the new flags register. These constants are the single
+// source of truth - previously each emitter hardcoded its own copy of the
+// magic numbers (64767, SA offsets, stack layout), and the TF/IRQ overrides
+// in emit-css.mjs used `calc(SP - 6)` without the --lowerBytes wrap that
+// protects against SP=0 underflow.
+
+// 0xFCFF = ~(IF | TF) & 0xFFFF - clears bits 8 (TF) and 9 (IF).
+export const INT_FLAGS_MASK = 64767;
+
+// CSS expression: new flags = old flags with IF+TF cleared.
+export const INT_CLEAR_FLAGS_EXPR = `--and(var(--__1flags), ${INT_FLAGS_MASK})`;
+
+// Stack frame layout: [SP-2]=FLAGS, [SP-4]=CS, [SP-6]=IP.
+// Offsets index into stackWriteAddr().
+export const INT_FRAME = [
+  { offset: 2, val: 'var(--__1flags)', name: 'FLAGS' },
+  { offset: 4, val: 'var(--__1CS)',    name: 'CS' },
+  { offset: 6, val: null,              name: 'IP' },  // retIP varies per caller
+];
+
+/**
+ * Emit a complete INT-style push frame for a single opcode.
+ *
+ * Handles: SP -= 6, load IP+CS from IVT, clear IF+TF, push FLAGS/CS/retIP.
+ * Caller provides the variant-specific parameters.
+ *
+ * @param {object}  dispatch   - DispatchTable instance
+ * @param {number}  opcode     - the opcode byte (0xCC, 0xCD, 0xCE)
+ * @param {string}  vectorExpr - CSS expr for the IVT entry index (e.g. 'var(--q1)' or '3')
+ * @param {string}  retIPExpr  - CSS expr for the return IP to push
+ * @param {string}  label      - comment prefix (e.g. 'INT', 'INT 3')
+ */
+export function emitIntFrame(dispatch, opcode, { vectorExpr, retIPExpr, label }) {
+  dispatch.addEntry('SP', opcode, spDecBy(6), `${label} (SP-=6)`);
+
+  dispatch.addEntry('IP', opcode,
+    `--read2(calc(${vectorExpr} * 4))`,
+    `${label} load IP from IVT`);
+
+  dispatch.addEntry('CS', opcode,
+    `--read2(calc(${vectorExpr} * 4 + 2))`,
+    `${label} load CS from IVT`);
+
+  dispatch.addEntry('flags', opcode,
+    INT_CLEAR_FLAGS_EXPR,
+    `${label} clear IF+TF`);
+
+  // 8086 INT pushes: FLAGS first (highest addr), then CS, then IP (lowest).
+  dispatch.addMemWriteWord(opcode,
+    stackWriteAddr(2),
+    `var(--__1flags)`,
+    `${label} push FLAGS`);
+
+  dispatch.addMemWriteWord(opcode,
+    stackWriteAddr(4),
+    `var(--__1CS)`,
+    `${label} push CS`);
+
+  dispatch.addMemWriteWord(opcode,
+    stackWriteAddr(6),
+    retIPExpr,
+    `${label} push IP`);
+}


### PR DESCRIPTION
Extract the shared INT-family push frame (SP-=6, push FLAGS/CS/IP, clear IF+TF, load IP+CS from IVT) into a single source of truth in stack-addr.mjs.

Changes:
- stack-addr.mjs: add INT_FLAGS_MASK (64767 = 0xFCFF), INT_CLEAR_FLAGS_EXPR, INT_FRAME layout, and emitIntFrame() helper.
- control.mjs: INT (0xCD) now calls emitIntFrame() — 35 lines → 6.
- misc.mjs: INT3 (0xCC) now calls emitIntFrame() — 24 lines → 6. INTO (0xCE) uses INT_CLEAR_FLAGS_EXPR constant (can't use the helper directly due to its OF-conditional arithmetic mux).
- emit-css.mjs: TF_OVERRIDES and IRQ_OVERRIDES now use spDecBy(6) and INT_CLEAR_FLAGS_EXPR. Memory write slot frame layout derived from INT_FRAME instead of local arrays.

Bug fix: TF trap and HW IRQ SP decrements previously used bare 'calc(var(--__1SP) - 6)' without the --lowerBytes(…+65536, 16) wrap that protects against SP underflow at SP ≤ 5. Now uses spDecBy(6) which includes the wrap — consistent with INT/INT3/INTO/PUSH/CALL. This adds 1 new --lowerBytes wrap in the generated CSS (+38 bytes).

Net: -20 lines, 5 previously independent copies of the magic number 64767 reduced to 1, and a latent SP underflow bug fixed.

Addresses #20